### PR TITLE
Fix Issue #4 - Silence uninitialized warnings

### DIFF
--- a/bzip2-src/compress.c
+++ b/bzip2-src/compress.c
@@ -253,8 +253,8 @@ void sendMTFValues ( EState* s )
    --*/
 
 
-   UInt16 cost[BZ_N_GROUPS];
-   Int32  fave[BZ_N_GROUPS];
+   UInt16 cost[BZ_N_GROUPS] = {0, 0, 0, 0, 0, 0};
+   Int32  fave[BZ_N_GROUPS] = {0, 0, 0, 0, 0, 0};
 
    UInt16* mtfv = s->mtfv;
 


### PR DESCRIPTION
Since cost is not initialized and the compiler cannot tell
if they are properly initialized (they are) warnings are produced
when building in blead perl under certain compilers.

This patch silences the warnings by making sure the data structures
are initialized to 0.

Warnings silenced:

    gcc -c  -I. -D_REENTRANT -D_GNU_SOURCE -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -Wall -Werror=pointer-arith -Werror=vla -Wextra -Wno-long-long -Wno-declaration-after-statement -Wc++-compat -Wwrite-strings -O3   -DVERSION=\"2.101\" -DXS_VERSION=\"2.101\" -fPIC "-I../.."  -Wall -Wno-comment  -DBZ_NO_STDIO  compress.c
    compress.c: In function ‘BZ2_compressBlock’:
    compress.c:392:54: warning: ‘cost[5]’ may be used uninitialized in this function [-Wmaybe-uninitialized]
		    for (t = 0; t < nGroups; t++) cost[t] += s->len[t][icv];
							  ^~
    compress.c:256:11: note: ‘cost[5]’ was declared here
	UInt16 cost[BZ_N_GROUPS];
	       ^~~~
    compress.c:402:21: warning: ‘cost[3]’ may be used uninitialized in this function [-Wmaybe-uninitialized]
		 if (cost[t] < bc) { bc = cost[t]; bt = t; };
		     ~~~~^~~
    compress.c:256:11: note: ‘cost[3]’ was declared here
	UInt16 cost[BZ_N_GROUPS];
	       ^~~~
    compress.c:402:21: warning: ‘cost[2]’ may be used uninitialized in this function [-Wmaybe-uninitialized]
		 if (cost[t] < bc) { bc = cost[t]; bt = t; };
		     ~~~~^~~
    compress.c:256:11: note: ‘cost[2]’ was declared here
	UInt16 cost[BZ_N_GROUPS];
	       ^~~~