### PR TITLE
Cast isdigit argument as unsigned char

### DIFF
--- a/bzip2-src/bzlib.c
+++ b/bzip2-src/bzlib.c
@@ -1415,7 +1415,7 @@ BZFILE * bzopen_or_bzdopen
       case 's':
          smallMode = 1; break;
       default:
-         if (isdigit((int)(*mode))) {
+         if (isdigit((unsigned char)(*mode))) {
             blockSize100k = *mode-BZ_HDR_0;
          }
       }


### PR DESCRIPTION
Theo noticed that these isdigit calls were not obviously correct. He suggested reporting this upstream.  The only portable safe way is to always cast to (unsigned char).

http://man.openbsd.org/isdigit#CAVEATS
> The argument c must be EOF or representable as an unsigned char;
> otherwise, the result is undefined.

Originally filed as https://github.com/Perl/perl5/pull/20649