### PR TITLE
silence unused variable warnings

### DIFF
--- a/Bzip2.xs
+++ b/Bzip2.xs
@@ -373,9 +373,6 @@ new(className, appendOut=1, blockSize100k=1, workfactor=0, verbosity=0)
             s = NULL ;
 	}
 	else {
-            int flags = 0 ;
-            if (appendOut)
-                flags |= FLAG_APPEND_OUTPUT;
             PostInitStream(s, appendOut ? FLAG_APPEND_OUTPUT :0) ;
         }
     }

--- a/bzip2-src/blocksort.c
+++ b/bzip2-src/blocksort.c
@@ -764,6 +764,9 @@ void mainSort ( UInt32* ptr,
    UChar  c1;
    Int32  numQSorted;
    UInt16 s;
+
+   ((void)numQSorted); /* Silence variable ‘numQSorted’ set but not used warning */
+
    if (verb >= 4) VPrintf0 ( "        main sort initialise ...\n" );
 
    /*-- set up the 2-byte frequency table --*/

--- a/bzip2-src/compress.c
+++ b/bzip2-src/compress.c
@@ -266,6 +266,7 @@ void sendMTFValues ( EState* s )
    UInt16* mtfv = s->mtfv;
 
    ((void)nBytes); /* Silence variable ‘nBytes’ set but not used warning */
+   ((void)totc); /* Silence variable ‘totc’ set but not used warning */
    if (s->verbosity >= 3)
       VPrintf3( "      %d in block, %d after MTF & 1-2 coding, "
                 "%d+2 syms in use\n",


### PR DESCRIPTION
Some variables are calculated but are not always used due to different macros. Add casts to void to silence warnings about them being unused.

Remove another variable that was not used.